### PR TITLE
Allow user to change own password when no MFA is present

### DIFF
--- a/modules/iam-group-with-policies/policies.tf
+++ b/modules/iam-group-with-policies/policies.tf
@@ -167,7 +167,8 @@ data "aws_iam_policy_document" "iam_self_management" {
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",
-        "sts:GetSessionToken"
+        "sts:GetSessionToken",
+        "iam:ChangePassword"
       ]
       resources = ["*"]
 


### PR DESCRIPTION
This allows a user to change their own password when no MFA is present on the account. This is only needed in once situation: when a new users signs in, and is then forced to choose a new password. The MFA isn't set up at that point, and the changing of the password is blocked.